### PR TITLE
Fractional units

### DIFF
--- a/defined_units.h
+++ b/defined_units.h
@@ -15,25 +15,26 @@ const char *base_units[N_UNITS] = {
 	"B",
 };
 
+/* Compromise: Allow the rational exponents but don't use more storage: 1, n/2, n/4 */
 const struct derived_unit_t si_derived_units[] = { /* https://en.wikipedia.org/wiki/International_System_of_Units#Derived_units */
 	/* The second is part of this table so we can easily detect its usage for printing it using the hh:mm:ss syntax */
-	{ "s",   {  0,  0,  1,  0,  0,  0,  0,  0,} }, /* second          time                                             s */
-	{ "Hz",  {  0,  0, -1,  0,  0,  0,  0,  0,} }, /* hertz           frequency                                        s^-1 */
-	{ "N",   {  1,  1, -2,  0,  0,  0,  0,  0,} }, /* newton          force, weight                                    kg·m·s^-2 */
-	{ "Pa",  { -1,  1, -2,  0,  0,  0,  0,  0,} }, /* pascal          pressure, stress                         N/m^2   kg·m^-1·s^-2 */
-	{ "J",   {  2,  1, -2,  0,  0,  0,  0,  0,} }, /* joule           energy, work, heat                       N·m     kg·m^2·s^-2 */
-	{ "W",   {  2,  1, -3,  0,  0,  0,  0,  0,} }, /* watt            power, radiant flux                      J/s     kg·m^2·s^-3 */
-	{ "C",   {  0,  0,  1,  1,  0,  0,  0,  0,} }, /* coulomb         electric charge                                  s·A */
-	{ "V",   {  2,  1, -3, -1,  0,  0,  0,  0,} }, /* volt            voltage                                  W/A     kg·m^2·s^-3·A^-1 */
-	{ "F",   { -2, -1,  4,  2,  0,  0,  0,  0,} }, /* farad           electric capacitance                     C/V     kg^-1·m^-2·s^4·A^2 */
-	{ "Ω",   {  2,  1, -3, -2,  0,  0,  0,  0,} }, /* ohm             electric resistance, impedance           V/A     kg·m^2·s^-3·A^-2 */
-	{ "S",   { -2, -1,  3,  2,  0,  0,  0,  0,} }, /* siemens         electrical conductance                   A/V     kg^-1·m^-2·s^3·A^2 */
-	{ "Wb",  {  2,  1, -2, -1,  0,  0,  0,  0,} }, /* weber           magnetic flux                            V·s     kg·m^2·s^-2·A^-1 */
-	{ "T",   {  0,  1, -2, -1,  0,  0,  0,  0,} }, /* tesla           magnetic flux density                    Wb/m^2  kg·s^-2·A^-1 */
-	{ "H",   {  2,  1, -2, -2,  0,  0,  0,  0,} }, /* henry           inductance                               Wb/A    kg·m^2·s^-2·A^-2 */
-	{ "lx",  { -2,  0,  0,  0,  0,  0,  1,  0,} }, /* lux             illuminance                              lm/m^2  m^-2·cd */
-	{ "Gy",  {  2,  0, -2,  0,  0,  0,  0,  0,} }, /* gray            absorbed dose (of ionizing radiation)    J/kg    m^2·s^-2 */
-	{ "kat", {  0,  0, -1,  0,  0,  1,  0,  0,} }, /* katal           catalytic activity                               mol·s^-1 */
+	{ "s",  { 0*4,  0*4,  1*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* second          time                                             s */
+	{ "Hz", { 0*4,  0*4, -1*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* hertz           frequency                                        s^-1 */
+	{ "N",  { 1*4,  1*4, -2*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* newton          force*4, weight                                    kg·m·s^-2 */
+	{ "Pa", {-1*4,  1*4, -2*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* pascal          pressure*4, stress                         N/m^2   kg·m^-1·s^-2 */
+	{ "J",  { 2*4,  1*4, -2*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* joule           energy*4, work*4, heat                       N·m     kg·m^2·s^-2 */
+	{ "W",  { 2*4,  1*4, -3*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* watt            power*4, radiant flux                      J/s     kg·m^2·s^-3 */
+	{ "C",  { 0*4,  0*4,  1*4,  1*4,  0*4,  0*4,  0*4,  0*4} }, /* coulomb         electric charge                                  s·A */
+	{ "V",  { 2*4,  1*4, -3*4, -1*4,  0*4,  0*4,  0*4,  0*4} }, /* volt            voltage                                  W/A     kg·m^2·s^-3·A^-1 */
+	{ "F",  {-2*4, -1*4,  4*4,  2*4,  0*4,  0*4,  0*4,  0*4} }, /* farad           electric capacitance                     C/V     kg^-1·m^-2·s^4·A^2 */
+	{ "Ω",  { 2*4,  1*4, -3*4, -2*4,  0*4,  0*4,  0*4,  0*4} }, /* ohm             electric resistance*4, impedance           V/A     kg·m^2·s^-3·A^-2 */
+	{ "S",  {-2*4, -1*4,  3*4,  2*4,  0*4,  0*4,  0*4,  0*4} }, /* siemens         electrical conductance                   A/V     kg^-1·m^-2·s^3·A^2 */
+	{ "Wb", { 2*4,  1*4, -2*4, -1*4,  0*4,  0*4,  0*4,  0*4} }, /* weber           magnetic flux                            V·s     kg·m^2·s^-2·A^-1 */
+	{ "T",  { 0*4,  1*4, -2*4, -1*4,  0*4,  0*4,  0*4,  0*4} }, /* tesla           magnetic flux density                    Wb/m^2  kg·s^-2·A^-1 */
+	{ "H",  { 2*4,  1*4, -2*4, -2*4,  0*4,  0*4,  0*4,  0*4} }, /* henry           inductance                               Wb/A    kg·m^2·s^-2·A^-2 */
+	{ "lx", {-2*4,  0*4,  0*4,  0*4,  0*4,  0*4,  1*4,  0*4} }, /* lux             illuminance                              lm/m^2  m^-2·cd */
+	{ "Gy", { 2*4,  0*4, -2*4,  0*4,  0*4,  0*4,  0*4,  0*4} }, /* gray            absorbed dose (of ionizing radiation)    J/kg    m^2·s^-2 */
+	{ "kat",{ 0*4,  0*4, -1*4,  0*4,  0*4,  1*4,  0*4,  0*4} }, /* katal           catalytic activity                               mol·s^-1 */
 	{ 0 }
 };
 

--- a/unit.c
+++ b/unit.c
@@ -75,7 +75,7 @@ unit_get_definitions(void)
 			strlcpy(unit_name->name, base_units[i], UNIT_NAME_LENGTH);
 			unit_name->unit_shift.unit.value = 1.0;
 			memset(unit_name->unit_shift.unit.units, 0, N_UNITS);
-			unit_name->unit_shift.unit.units[i] = 1;
+			unit_name->unit_shift.unit.units[i] = 4;
 			unit_name->unit_shift.shift = 0.0;
 		}
 	}
@@ -209,6 +209,18 @@ static char *superscripts[] = {
 static void
 print_exponent (char **output_p, int e)
 {
+    /* Rational Exponent. Two least significant bits represent 1/2 and 1/4 .*/
+    if (abs(e)%4) {
+        /* /2 or /4 */
+        *output_p += sprintf(*output_p,"^%.2f",e/4.0);
+        return;
+    }
+
+    /* Integer Exponent */
+    e /= 4;
+    if(e == 1) {
+        return;
+    }
 	if (unit_output_superscript) {
 		char  ascii_exp[5];
 		int   i = 0;
@@ -594,7 +606,7 @@ unit_meter (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_m] = 1;
+	result->units[UNIT_m] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -607,7 +619,7 @@ unit_kilogram (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_kg] = 1;
+	result->units[UNIT_kg] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -620,7 +632,7 @@ unit_second (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_s] = 1;
+	result->units[UNIT_s] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -633,7 +645,7 @@ unit_ampere (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_A] = 1;
+	result->units[UNIT_A] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -646,7 +658,7 @@ unit_kelvin (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_K] = 1;
+	result->units[UNIT_K] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -659,7 +671,7 @@ unit_mole (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_mol] = 1;
+	result->units[UNIT_mol] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -672,7 +684,7 @@ unit_candela (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_cd] = 1;
+	result->units[UNIT_cd] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -685,7 +697,7 @@ unit_byte (PG_FUNCTION_ARGS)
 
 	result = (Unit *) palloc0(sizeof(Unit));
 	result->value = PG_GETARG_FLOAT8(0);
-	result->units[UNIT_B] = 1;
+	result->units[UNIT_B] = 4;
 	PG_RETURN_POINTER(result);
 }
 
@@ -893,7 +905,7 @@ Datum
 unit_pow(PG_FUNCTION_ARGS)
 {
 	Unit	*a = (Unit *) PG_GETARG_POINTER(0);
-	int		 b = PG_GETARG_INT32(1);
+    int              b = PG_GETARG_INT32(1);
 	Unit	*result;
 	int		 i;
 

--- a/unit.c
+++ b/unit.c
@@ -210,17 +210,19 @@ static void
 print_exponent (char **output_p, int e)
 {
     /* Rational Exponent. Two least significant bits represent 1/2 and 1/4 .*/
-    if (abs(e)%4) {
+    if (abs(e)%4) 
+	{
         /* /2 or /4 */
         *output_p += sprintf(*output_p,"^%.2f",e/4.0);
         return;
     }
 
-    /* Integer Exponent */
-    e /= 4;
-    if(e == 1) {
-        return;
-    }
+	/* Integer Exponent */
+	e /= 4;
+	if(e == 1) 
+	{
+		return;
+	}
 	if (unit_output_superscript) {
 		char  ascii_exp[5];
 		int   i = 0;

--- a/unit.c
+++ b/unit.c
@@ -209,7 +209,7 @@ static char *superscripts[] = {
 static void
 print_exponent (char **output_p, int e)
 {
-    /* Rational Exponent. Two least significant bits represent 1/2 and 1/4 .*/
+	/* Rational Exponent. Two least significant bits represent 1/2 and 1/4 .*/
 	if (abs(e)%4) 
 	{
 		/* /2 or /4 */

--- a/unit.c
+++ b/unit.c
@@ -210,12 +210,12 @@ static void
 print_exponent (char **output_p, int e)
 {
     /* Rational Exponent. Two least significant bits represent 1/2 and 1/4 .*/
-    if (abs(e)%4) 
+	if (abs(e)%4) 
 	{
-        /* /2 or /4 */
-        *output_p += sprintf(*output_p,"^%.2f",e/4.0);
-        return;
-    }
+		/* /2 or /4 */
+		*output_p += sprintf(*output_p,"^%.2f",e/4.0);
+		return;
+	}
 
 	/* Integer Exponent */
 	e /= 4;

--- a/unitparse.l
+++ b/unitparse.l
@@ -312,13 +312,14 @@ found:
 
 {EXP_R} {
 	yyunitlval.EXPONENT = atof(yytext+1);
-    /* check if fractional portion of exponent is .0 .25 .5 .75 */
-    if (fmod(4.0*fabs(yyunitlval.EXPONENT),1.0) > 1e-12) {
+	/* check if fractional portion of exponent is .0 .25 .5 .75 */
+	if (fmod(4.0*fabs(yyunitlval.EXPONENT),1.0) > 1e-12) 
+	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("unit exponent is not allowed \"%s\". Fractional part must be be one of: .0, .25, .5, .75. ", yytext)));
-        return ERR;
-    }
+					errmsg("unit exponent is not allowed \"%s\". Fractional part must be be one of: .0, .25, .5, .75. ", yytext)));
+		return ERR;
+	}
 	return EXPONENT;
 }
 

--- a/unitparse.l
+++ b/unitparse.l
@@ -52,7 +52,7 @@ ALNUM   [a-zA-Z$%'"_0-9]|{UTF8}
 DOUBLE_R [0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?
 TIME_R   [0-9]+:[0-9]+:[0-9]+(\.[0-9]+)?
 UNIT_R   {ALPHA}{ALNUM}*
-EXP_R    \^[\-+]?[0-9]+
+EXP_R    \^[\-+]?[0-9]*\.?[0-9]+
 
 SUPER_PLUS  \xe2\x81\xba
 SUPER_MINUS \xe2\x81\xbb
@@ -311,7 +311,14 @@ found:
 }
 
 {EXP_R} {
-	yyunitlval.EXPONENT = atoi(yytext+1);
+	yyunitlval.EXPONENT = atof(yytext+1);
+    /* check if fractional portion of exponent is .0 .25 .5 .75 */
+    if (fmod(4.0*fabs(yyunitlval.EXPONENT),1.0) > 1e-12) {
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("unit exponent is not allowed \"%s\". Fractional part must be be one of: .0, .25, .5, .75. ", yytext)));
+        return ERR;
+    }
 	return EXPONENT;
 }
 

--- a/unitparse.tab.c
+++ b/unitparse.tab.c
@@ -154,18 +154,18 @@ union YYUNITSTYPE
   UnitShift simple_expr;
   /* DOUBLE  */
   double DOUBLE;
+  /* EXPONENT  */
+  double EXPONENT;
+  /* SUPER_SIGN  */
+  double SUPER_SIGN;
+  /* SUPER  */
+  double SUPER;
   /* number  */
   double number;
-  /* EXPONENT  */
-  int EXPONENT;
-  /* SUPER_SIGN  */
-  int SUPER_SIGN;
-  /* SUPER  */
-  int SUPER;
   /* exponent  */
-  int exponent;
+  double exponent;
   /* super  */
-  int super;
+  double super;
 #line 170 "unitparse.tab.c" /* yacc.c:355  */
 };
 
@@ -1313,10 +1313,10 @@ yyreduce:
 #line 67 "unitparse.y" /* yacc.c:1646  */
     {
 	int i;
-	if ((*(int*)(&yyvsp[0])) != 1) {
-		(*(UnitShift*)(&yyval)).unit.value = pow((*(UnitShift*)(&yyvsp[-1])).unit.value, (*(int*)(&yyvsp[0])));
+	if ((*(double*)(&yyvsp[0])) != 1) {
+		(*(UnitShift*)(&yyval)).unit.value = pow((*(UnitShift*)(&yyvsp[-1])).unit.value, (*(double*)(&yyvsp[0])));
 		for (i = 0; i < N_UNITS; i++)
-			(*(UnitShift*)(&yyval)).unit.units[i] = (*(UnitShift*)(&yyvsp[-1])).unit.units[i] * (*(int*)(&yyvsp[0]));
+			(*(UnitShift*)(&yyval)).unit.units[i] = (*(UnitShift*)(&yyvsp[-1])).unit.units[i] * (*(double*)(&yyvsp[0]));
 	} else {
 		(*(UnitShift*)(&yyval)) = (*(UnitShift*)(&yyvsp[-1]));
 	}
@@ -1411,13 +1411,13 @@ yyreduce:
 
   case 19:
 #line 127 "unitparse.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = (*(int*)(&yyvsp[-1])) * (*(int*)(&yyvsp[0])); }
+    { (*(double*)(&yyval)) = (*(double*)(&yyvsp[-1])) * (*(double*)(&yyvsp[0])); }
 #line 1416 "unitparse.tab.c" /* yacc.c:1646  */
     break;
 
   case 22:
 #line 133 "unitparse.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = 10 * (*(int*)(&yyvsp[-1])) + (*(int*)(&yyvsp[0])); }
+    { (*(double*)(&yyval)) = 10 * (*(double*)(&yyvsp[-1])) + (*(double*)(&yyvsp[0])); }
 #line 1422 "unitparse.tab.c" /* yacc.c:1646  */
     break;
 

--- a/unitparse.tab.h
+++ b/unitparse.tab.h
@@ -79,18 +79,18 @@ union YYUNITSTYPE
   UnitShift simple_expr;
   /* DOUBLE  */
   double DOUBLE;
+  /* EXPONENT  */
+  double EXPONENT;
+  /* SUPER_SIGN  */
+  double SUPER_SIGN;
+  /* SUPER  */
+  double SUPER;
   /* number  */
   double number;
-  /* EXPONENT  */
-  int EXPONENT;
-  /* SUPER_SIGN  */
-  int SUPER_SIGN;
-  /* SUPER  */
-  int SUPER;
   /* exponent  */
-  int exponent;
+  double exponent;
   /* super  */
-  int super;
+  double super;
 #line 95 "unitparse.tab.h" /* yacc.c:1909  */
 };
 

--- a/unitparse.y
+++ b/unitparse.y
@@ -32,11 +32,11 @@ static UnitShift *unit_parse_result; /* parsing result gets stored here */
 %define api.value.type union
 %token <double> DOUBLE
 %token <UnitShift> UNIT_SHIFT
-%token <int> EXPONENT SUPER_SIGN SUPER
+%token <double> EXPONENT SUPER_SIGN SUPER
 %token ERR
 %type  <UnitShift> input expr simple_expr
 %type  <double> number
-%type  <int> exponent super
+%type  <double> exponent super
 
 %left '+' '-'
 %left '/'


### PR DESCRIPTION
This is an idea to allow fractional dimension units that are powers of 1/2 or 1/4. We use the same amount of storage and just shift all the unit definitions to the left two bits and use those two bits as the binary fractions .5 and .25. 

For example we can represent fracture toughness this way... 

```
unit_databases=# select '1.0 psi * in^.5'::unit;
              unit
--------------------------------
 1098.84349410875 kg/m^0.50*s^2
(1 row)

unit_databases=# select '1.0 ksi * in^.5'::unit;
              unit
--------------------------------
 1098843.49410875 kg/m^0.50*s^2
(1 row)

unit_databases=# select '1.0 ksi * in^.52'::unit;
ERROR:  unit exponent is not allowed "^.52". Fractional part must be be one of: .0, .25, .5, .75.
LINE 1: select '1.0 ksi * in^.52'::unit;
```