### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+postgresql-unit (7.5-3) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on bison.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 24 Oct 2022 16:32:10 -0000
+
 postgresql-unit (7.5-2) unstable; urgency=medium
 
   * Upload for PostgreSQL 15.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Christoph Berg <myon@debian.org>
 Build-Depends:
- bison (>> 2:3),
+ bison,
  debhelper-compat (= 13),
  flex,
  postgresql-server-dev-all (>= 217~),


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/postgresql-unit/3e3b2b71-c83f-402a-a1d5-7c830106305f.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/3e3b2b71-c83f-402a-a1d5-7c830106305f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/3e3b2b71-c83f-402a-a1d5-7c830106305f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/3e3b2b71-c83f-402a-a1d5-7c830106305f/diffoscope)).
